### PR TITLE
Update instructions for storing script properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple script to synchronize your Peloton schedule with Google Calendar. peloC
 ## Setup
 
 1. Make a copy of [the deployed script](https://script.google.com/d/1Hc9ncp32lwjjKcR0XCB6QjZAQep0BpRE1mFQkmzMDwp9a711mCYEAmAb/edit?usp=sharing) to your Google account by choosing the Overview tab then clicking the Copy icon on the top right.
-2. Store your Peloton credentials in the `pelotonUsername` and `pelotonPassword` script properties. This unfortunately requires switching to the legacy editor.
+2. Store your Peloton credentials in the `pelotonUsername` and `pelotonPassword` script properties under **Project Settings** > **Script Properties**
 3. Deploy your project and set up a [time-driven trigger](https://developers.google.com/apps-script/guides/triggers/installable#time-driven_triggers) so it runs automatically.
 
 ## Notes


### PR DESCRIPTION
Apps Script (as of 2023) allows storing properties without using the legacy editor